### PR TITLE
Dankamongmen/um7 ros deps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package um7
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.0.2 (2015-02-20
+0.0.2 (2015-02-20)
+------------------
+*Initial release of um7 driver.  
 
-Initial release of um7 driver.  
------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,3 +3,6 @@ Changelog for package um7
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 0.0.2 (2015-02-20)
+
+Initial release of um7 driver.
+-----------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ros-melodic-um7 (0.0.4-bionic2) bionic; urgency=medium
+
+  * Add deps on ros-melodic-{serial, sensor-msgs, roscpp}
+
+ -- Nick Black <dankamongmen@gmail.com>  Sun, 29 Sep 2019 09:41:02 -0400
+
 ros-melodic-um7 (0.0.4-bionic1) bionic; urgency=medium
 
   * Initial release (Closes: #1198)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: ros-melodic-um7
 Section: misc
 Priority: optional
 Maintainer: nick black <dankamongmen@gmail.com>
-Build-Depends: debhelper-compat (= 12), cmake
+Build-Depends: debhelper-compat (= 12), cmake, ros-melodic-roscpp,
+ ros-melodic-sensor-msgs, ros-melodic-serial
 Standards-Version: 4.4.0
 Homepage: https://www.pololu.com/product/2764
 Vcs-Browser: https://github.com/Greenzie/um7
@@ -10,7 +11,8 @@ Vcs-Git: https://github.com/Greenzie/um7.git
 
 Package: ros-melodic-um7
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, ros-melodic-serial,
+ ros-melodic-sensor-msgs
 Description: ROS driver for the UM7 IMD
  ROS driver for the CH Robotics UM7 inertial measurement device.
  Supports standard data and mag topics as well as providing

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>um7</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>The um7 package provides a C++ implementation of the CH Robotics serial protocol, and a
     corresponding ROS node for publishing standard ROS orientation topics from a UM7.
   </description>


### PR DESCRIPTION
Add necessary deps to `debian/control`, fixing missing libserial.so (#1268).